### PR TITLE
Table Partitioning

### DIFF
--- a/src/Console/Commands/PartitionTableByDateRange.php
+++ b/src/Console/Commands/PartitionTableByDateRange.php
@@ -45,9 +45,9 @@ use InvalidArgumentException;
  *   `response_code` int NOT NULL,
  *   `response_body` json DEFAULT NULL,
  *   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
- *   `created_at_indexed` date NOT NULL DEFAULT (curdate()),
+ *   `date_partition_column` date NOT NULL DEFAULT (curdate()),
  *   PRIMARY KEY (`id`,`created_date`),
- *   KEY `wms_requests_created_at_indexed_index` (`created_at_indexed`)
+ *   KEY `wms_requests_date_partition_column_index` (`date_partition_column`)
  * ) ENGINE=InnoDB AUTO_INCREMENT=93327 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
  * /*!50100 PARTITION BY RANGE (to_days(`created_date`))
  * (PARTITION p20230925 VALUES LESS THAN (739154) ENGINE = InnoDB,
@@ -70,7 +70,7 @@ class PartitionTableByDateRange extends Command
                             {tableName : The name of the table to partition}
                             {startDate : The starting partition date in the format of ' . Constants::MYSQL_DATE_FORMAT . ', typically, in the past.}
                             {endDate : The concluding partition date in the format of ' . Constants::MYSQL_DATE_FORMAT . ', typically, in the future.}
-                            {--partitionColumnName=created_at_indexed : The name of the column to partition against}
+                            {--partitionColumnName=date_partition_column : The name of the column to partition against}
                             {--blueprint= : A special option used internally when this command is invoked programmatically via migrations.  It should not be used via the CLI.}
                             {--databaseManagerStatements=  : A special option used internally when this command is invoked programmatically via migrations.  It should not be used via the CLI.}';
 

--- a/src/Console/Commands/PartitionTableByDateRange.php
+++ b/src/Console/Commands/PartitionTableByDateRange.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace GuaranteedSoftware\Laravel\DatasourceTools\Console\Commands;
+
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use GuaranteedSoftware\Laravel\DatasourceTools\Contracts\Constants;
+use GuaranteedSoftware\Laravel\DatasourceTools\Helpers\DbHelper;
+use GuaranteedSoftware\Laravel\DatasourceTools\Providers\DatasourceToolsServiceProvider;
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+
+/**
+ * A command to split a table into partitions by dates across a range of dates
+ *
+ * Example usage:
+ *
+ * php artisan table:partition-by-date wms_requests 2023-09-25 2023-10-01 --created_at_index
+ *
+ * EXECUTING STATEMENT:
+ * ALTER TABLE wms_requests
+ *   PARTITION by range (to_days(created_date))
+ *   (
+ *     partition p20230925 VALUES LESS THAN (to_days('2023-09-26')),
+ *     partition p20230926 VALUES LESS THAN (to_days('2023-09-27')),
+ *     partition p20230927 VALUES LESS THAN (to_days('2023-09-28')),
+ *     partition p20230928 VALUES LESS THAN (to_days('2023-09-29')),
+ *     partition p20230929 VALUES LESS THAN (to_days('2023-09-30')),
+ *     partition p20230930 VALUES LESS THAN (to_days('2023-10-01')),
+ *     partition p20231001 VALUES LESS THAN (to_days('2023-10-02')),
+ *     partition pMAXVALUE VALUES LESS THAN MAXVALUE
+ *   );
+ *
+ * RESULTED TABLE STRUCTURE:
+ * CREATE TABLE `wms_requests` (
+ *   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+ *   `method` varchar(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `host` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `path` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `body` json DEFAULT NULL,
+ *   `response_code` int NOT NULL,
+ *   `response_body` json DEFAULT NULL,
+ *   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *   `created_at_indexed` date NOT NULL DEFAULT (curdate()),
+ *   PRIMARY KEY (`id`,`created_date`),
+ *   KEY `wms_requests_created_at_indexed_index` (`created_at_indexed`)
+ * ) ENGINE=InnoDB AUTO_INCREMENT=93327 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+ * /*!50100 PARTITION BY RANGE (to_days(`created_date`))
+ * (PARTITION p20230925 VALUES LESS THAN (739154) ENGINE = InnoDB,
+ *  PARTITION p20230926 VALUES LESS THAN (739155) ENGINE = InnoDB,
+ *  PARTITION p20230927 VALUES LESS THAN (739156) ENGINE = InnoDB,
+ *  PARTITION p20230928 VALUES LESS THAN (739157) ENGINE = InnoDB,
+ *  PARTITION p20230929 VALUES LESS THAN (739158) ENGINE = InnoDB,
+ *  PARTITION p20230930 VALUES LESS THAN (739159) ENGINE = InnoDB,
+ *  PARTITION p20231001 VALUES LESS THAN (739160) ENGINE = InnoDB,
+ *  PARTITION pMAXVALUE VALUES LESS THAN MAXVALUE ENGINE = InnoDB)
+ */
+class PartitionTableByDateRange extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'table:partition-by-date
+                            {tableName : The name of the table to partition}
+                            {startDate : The starting partition date in the format of ' . Constants::MYSQL_DATE_FORMAT . ', typically, in the past.}
+                            {endDate : The concluding partition date in the format of ' . Constants::MYSQL_DATE_FORMAT . ', typically, in the future.}
+                            {--partitionColumnName=created_at_indexed : The name of the column to partition against}
+                            {--blueprint= : A special option used internally when this command is invoked programmatically via migrations.  It should not be used via the CLI.}
+                            {--databaseManagerStatements=  : A special option used internally when this command is invoked programmatically via migrations.  It should not be used via the CLI.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Partition provided table by range on created_date column';
+
+    /**
+     * The name of the table to partition
+     *
+     * @var string
+     */
+    private string $tableName= '';
+
+    /**
+     * The name of the column to partition against
+     *
+     * @var string
+     */
+    private string $partitionColumnName = '';
+
+    /**
+     * The starting partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}
+     * Typically, this date should be in the past
+     *
+     * @var string
+     */
+    private string $startDate = '';
+
+    /**
+     * The concluding partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}
+     * Typically, this date should be in the future
+     *
+     * @var string
+     */
+    private string $endDate = '';
+
+    /**
+     * The table blueprint used for manipulating schemas in the migration context.  If this value has been
+     * set, then this command will operate in "blueprint" mode, performing actions against the blueprint instead
+     * of generating and running migration files.
+     *
+     * @var ?Blueprint
+     */
+    private ?Blueprint $tableBlueprint;
+
+    /**
+     * A stack of statements to be executed against the table, used in the migration context. If a blueprint has been
+     * set, then this command will operate in "blueprint" mode, will add statements to this queue instead
+     * of generating and running migration files.  These statements are expected to be run by the caller after command
+     * completion.
+     *
+     * @var array
+     */
+    private array $databaseManagerStatements = [];
+
+    /**
+     * Execute the console command to split a table into partitions
+     *
+     * @return int  exit codes: SUCCESS = 0, FAILURE = 1, INVALID = 2
+     */
+    public function handle(): int
+    {
+        $this->tableName = $this->argument('tableName');
+        $this->startDate = $this->argument('startDate');
+        $this->endDate = $this->argument('endDate');
+        $this->partitionColumnName = $this->option('partitionColumnName');
+        $this->tableBlueprint = $this->option('blueprint');
+        $this->databaseManagerStatements = $this->option('$databaseManagerStatements');
+
+        try {
+            $this->validateArguments();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            $this->call('help', ['command_name' => 'table:partition-by-date', 'format' => 'raw']);
+            return self::INVALID;
+        }
+
+        if (!Schema::hasColumn($this->tableName, $this->partitionColumnName)) {
+            if ($this->tableBlueprint) {
+                $this->addPartitionColumnToBlueprint();
+
+                if (Schema::hasColumn($this->tableName, 'created_at')) {
+                    $this->databaseManagerStatements[] = "UPDATE $this->tableName SET $this->partitionColumnName = date(created_at);";
+                }
+            } else {
+                $this->makeAddPartitionColumnMigrationFile();
+            }
+        }
+
+        if ($this->tableBlueprint) {
+            $this->databaseManagerStatements[] = $this->getPartitionStatement();
+        } else {
+            $this->makeCreatePartitionsMigrationFile();
+
+            Artisan::call('migrate');
+
+            $this->comment('RESULTED TABLE STRUCTURE:');
+            $this->info(DB::select(DB::raw("SHOW CREATE TABLE $this->tableName ;"))[0]->{'Create Table'});
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     *  Checks all arguments and ensures that they are valid in order to partition the table
+     *
+     * @return void
+     * @throws InvalidArgumentException if any argument passed to this command is invalid.
+     *                                  This includes tables that are not in the expected
+     *                                  state or that do not exist.
+     */
+    private function validateArguments(): void
+    {
+        $error = '';
+
+        if (!$this->isValidDateRange($this->startDate, $this->endDate)) {
+            $this->error(
+                $error .= "Invalid input date(s) !!! startDate: [$this->startDate], endDate: [$this->endDate]\n"
+                    . "expected format: [" . Constants::MYSQL_DATE_FORMAT . "] where the startDate is before"
+                    . " the endDate.\n"
+            );
+        }
+
+        if (!Schema::hasTable($this->tableName)) {
+            $this->error($error .= "Invalid table name entry. `$this->tableName` was not found.\n");
+        }
+
+        if (DbHelper::discoversTableIsAlreadyPartitioned($this->tableName)) {
+            $this->error($error .= "Table `$this->tableName` has already been partitioned.\n");
+        }
+
+        if (!$this->partitionColumnName) {
+            $this->error($error .= "Argument partitionColumnName is required!!!\n");
+        }
+
+        $idDefinition = '';
+        if (
+            !Schema::hasColumn($this->tableName, 'id')
+            || (
+                !str_starts_with(
+                    $idDefinition = Schema::getColumnType($this->tableName, 'id', true),
+                    'int'
+                )
+                && !str_starts_with($idDefinition, 'bigint')
+            )
+            || !str_contains($idDefinition, 'primary key')
+        ) {
+            $this->error(
+                $error .= "`$this->tableName` is required to have an `id` field of type `int` "
+                    . "or `bigint` and must make up the primary key. The current column definition "
+                    . "does not meet that criteria:\n\n"
+                    . "$idDefinition\n"
+            );
+        }
+
+        if (
+            Schema::hasColumn($this->tableName, $this->partitionColumnName)
+            && (
+                !str_starts_with(
+                    $partitionColumnDefinition = Schema::getColumnType($this->tableName, $this->partitionColumnName, true),
+                    'date'
+                )
+                || !str_contains($partitionColumnDefinition, 'primary key')
+                || !str_contains($idDefinition, 'unique')
+            )
+        ) {
+            $this->error(
+                $error .= "`$this->partitionColumnName` is required to be of type `date` "
+                    . "and must make up the primary key along with a `unique` `id` field. "
+                    . "The current column definitions do not meet that criteria\n\n:"
+                    . "$partitionColumnDefinition\n"
+                    . "$idDefinition\n"
+            );
+        }
+
+        if ($error) {
+            throw new InvalidArgumentException($error);
+        }
+    }
+
+    /**
+     * Check if the passed dates (as strings) satisfy the required date format and
+     * if the $startDate is less or equal to the $endDate
+     *
+     * @param string $startDate start of the date interval
+     * @param string $endDate   end of the date interval
+     *
+     * @return bool             true if date range is valid, otherwise false
+     */
+    private function isValidDateRange(string $startDate, string $endDate): bool
+    {
+        foreach ([$startDate, $endDate] as $date) {
+            if (
+                Carbon::createFromFormat(Constants::MYSQL_DATE_FORMAT, $date)
+                    ->format(Constants::MYSQL_DATE_FORMAT) !== $date
+            ) {
+                return false;
+            }
+        }
+        return $startDate <= $endDate;
+    }
+
+    /**
+     * Add the schema definition to the table blueprint.  This is used when the macro `Blueprint::partitionByDateRange`
+     * is invoked.
+     *
+     * @return void
+     *
+     * @see DatasourceToolsServiceProvider::boot()
+     * @see file: laravel-datasource-tools/stubs/database/migrations/add_partition_column.php - must be kept synced to this
+     */
+    private function addPartitionColumnToBlueprint(): void
+    {
+        $this->tableBlueprint->date($this->partitionColumnName)->default(DB::raw('(CURRENT_DATE)'))->index();
+        $this->tableBlueprint->unique(['id']);
+        $this->tableBlueprint->dropPrimary(['id']);
+        $this->tableBlueprint->primary(['id', $this->partitionColumnName]);
+    }
+
+    /**
+     * Creates and returns the partition statement for this table
+     *
+     * @return string a single `ALTER TABLE` statement that makes the partitions
+     */
+    private function getPartitionStatement(): string {
+        $period = CarbonPeriod::create($this->startDate, $this->endDate);
+
+        $partitionStatements = "";
+        foreach ($period as $date) {
+            $partitionStatements .=
+                "partition p{$date->format(Constants::PARTITION_NAME_DATE_FORMAT)} VALUES LESS THAN
+                 (to_days('{$date->add('days', 1)->format(Constants::MYSQL_DATE_FORMAT)}')),\n";
+        }
+
+        return
+            "ALTER TABLE $this->tableName
+            PARTITION by range (to_days($this->partitionColumnName))
+            (
+              $partitionStatements
+              partition pMAXVALUE VALUES LESS THAN MAXVALUE
+            );";
+    }
+
+    /**
+     * Adds the {@see self::$partitionColumnName} to the table {@see self::$tableName
+     *
+     * @return void
+     */
+    private function makeAddPartitionColumnMigrationFile(): void
+    {
+        $this->makeMigrationFile(
+            'add_partition_column',
+            [
+                '{{tableName}}' => $this->tableName,
+                '{{partitionColumnName}}' => $this->partitionColumnName,
+            ]
+        );
+    }
+
+    /**
+     * Adds the date-delimited partitions to $this->{@see PartitionTableByDateRange::$tableName}
+     * @return void
+     */
+    private function makeCreatePartitionsMigrationFile(): void
+    {
+
+        $this->makeMigrationFile(
+            'create_partitions',
+            [
+                '{{tableName}}' => $this->tableName,
+                '{{statement}}' => $this->getPartitionStatement(),
+            ]
+        );
+    }
+
+    /**
+     * Creates a migration file and stores it in the Laravel `database/migrations/` folder
+     *
+     * @param string $stubFileBaseName the base name, (i.e. name without the extension), of the stub file
+     *                                 located in this library's `stubs/database/migrations` folder
+     * @param array $textReplacements an associative array of text replacements where the keys are the
+     *                                text to be replaced in the stub files with the corresponding values
+     *                                in the array.  By convention, the keys follow the format
+     *                                `{{variableName}}`, but this is not a requirement.
+     *
+     * @return void
+     */
+    private function makeMigrationFile(string $stubFileBaseName, array $textReplacements): void
+    {
+        $stubFilePath = __DIR__ . "/../../../../../stubs/database/migrations/$stubFileBaseName.php";
+        $migrationFileContent = file_get_contents($stubFilePath);
+
+        foreach($textReplacements as $placeholder => $textReplacement) {
+            $migrationFileContent = str_replace($placeholder, $textReplacement, $migrationFileContent);
+        }
+
+        $timestamp = date('Y_m_d_His');
+        $migrationFilePath = database_path('migrations')  . "/{$timestamp}_{$stubFileBaseName}_to_$this->tableName.php";
+
+        file_put_contents($migrationFilePath, $migrationFileContent);
+    }
+}

--- a/src/Console/Commands/UpdateTablePartitions.php
+++ b/src/Console/Commands/UpdateTablePartitions.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace GuaranteedSoftware\Laravel\DatasourceTools\Console\Commands;
+
+use Carbon\Carbon;
+use GuaranteedSoftware\Laravel\DatasourceTools\Contracts\Constants;
+use GuaranteedSoftware\Laravel\DatasourceTools\Helpers\DbHelper;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+
+/**
+ * A command to delete an old partitions after a life span given in number of days, (historic). and to create
+ * new ones a given number of days into the future
+ *
+ * Example usage (as run on 2023-09-25):
+ *
+ * php artisan table:update-partitions wms_requests
+ *
+ * EXECUTING STATEMENT:
+ * ALTER TABLE wms_requests
+ *             REORGANIZE PARTITION pMAXVALUE INTO
+ *                 (PARTITION p20231002 VALUES LESS THAN
+ *                 (to_days('2023-10-03')),
+ *                 PARTITION pMAXVALUE VALUES LESS THAN MAXVALUE);
+ * EXECUTING STATEMENT:
+ * ALTER TABLE wms_requests DROP PARTITION p20230918;
+ * RESULTED TABLE STRUCTURE:
+ * CREATE TABLE `wms_requests` (
+ *   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+ *   `method` varchar(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `host` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `path` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+ *   `body` json DEFAULT NULL,
+ *   `response_code` int NOT NULL,
+ *   `response_body` json DEFAULT NULL,
+ *   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *   `created_date` date NOT NULL DEFAULT (curdate()),
+ *   PRIMARY KEY (`id`,`created_date`),
+ *   KEY `wms_requests_created_date_index` (`created_date`)
+ * ) ENGINE=InnoDB AUTO_INCREMENT=93327 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+ * /*!50100 PARTITION BY RANGE (to_days(`created_date`))
+ * (PARTITION p20230919 VALUES LESS THAN (739148) ENGINE = InnoDB,
+ *  PARTITION p20230920 VALUES LESS THAN (739149) ENGINE = InnoDB,
+ *  PARTITION p20230921 VALUES LESS THAN (739150) ENGINE = InnoDB,
+ *  PARTITION p20230922 VALUES LESS THAN (739151) ENGINE = InnoDB,
+ *  PARTITION p20230923 VALUES LESS THAN (739152) ENGINE = InnoDB,
+ *  PARTITION p20230924 VALUES LESS THAN (739153) ENGINE = InnoDB,
+ *  PARTITION p20230925 VALUES LESS THAN (739154) ENGINE = InnoDB,
+ *  PARTITION p20230926 VALUES LESS THAN (739155) ENGINE = InnoDB,
+ *  PARTITION p20230927 VALUES LESS THAN (739156) ENGINE = InnoDB,
+ *  PARTITION p20230928 VALUES LESS THAN (739157) ENGINE = InnoDB,
+ *  PARTITION p20230929 VALUES LESS THAN (739158) ENGINE = InnoDB,
+ *  PARTITION p20230930 VALUES LESS THAN (739159) ENGINE = InnoDB,
+ *  PARTITION p20231001 VALUES LESS THAN (739160) ENGINE = InnoDB,
+ *  PARTITION p20231002 VALUES LESS THAN (739161) ENGINE = InnoDB,
+ *  PARTITION pMAXVALUE VALUES LESS THAN MAXVALUE ENGINE = InnoDB)
+ */
+class UpdateTablePartitions extends Command
+{
+    /**
+     * When partitioning the table it only makes sense to have at least 2 active partitions
+     * (and the MAXVALUE fallback)
+     *
+     * TODO: Justify this statement - @danac
+     *
+     * @var int
+     */
+    public const MINIMUM_NUMBER_OF_PARTITIONS = 2;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'table:update-partitions
+                            {tableName : The name of the partitioned table to add/drop partitions}
+                            {futurePartitionCount=2 : Positive integer greater than 1. Number of pre-created partitions, one for each subsequent day in the future} 
+                            {historicPartitionCount=7 : Positive integer greater than 1. Partition life span in days - Partitions are deleted beyond the `historicPartitionCount` past days}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command to delete old partitions and create a new ones';
+
+    /**
+     * The name of the table to partition
+     *
+     * @var string
+     */
+    private string $tableName= '';
+
+    /**
+     * Number of pre-created partitions, one for each subsequent day in the future.
+     * Positive integer greater than 1.
+     * Defaults to 2
+     *
+     * @var int
+     */
+    private int $futurePartitionCount = 2;
+
+    /**
+     * A partition's life span in days - Partitions are deleted beyond the `historicPartitionCount` number of
+     * days in the past
+     * Positive integer greater than 1.
+     * Defaults to 7
+     *
+     * @var int
+     */
+    private int $historicPartitionCount = 7;
+
+    /**
+     * Execute the console command
+     * to delete the old partitions beyond the "historic day count" and create a new ones the
+     * "future partition count" into the future
+     *
+     * @return int  exit codes: SUCCESS = 0, FAILURE = 1, INVALID = 2
+     */
+    public function handle(): int
+    {
+        $this->tableName = $this->argument('tableName');
+        $this->futurePartitionCount = $this->argument('futurePartitionCount');
+        $this->historicPartitionCount = $this->argument('historicPartitionCount');
+
+        try {
+            $this->validateArguments();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            $this->call('help', ['command_name' => 'table:update-partitions', 'format' => 'raw']);
+            return self::INVALID;
+        }
+
+        $futureBoundaryDate = Carbon::today()->add('days', $this->futurePartitionCount);
+        $pastBoundaryDate = Carbon::today()->sub('days', $this->historicPartitionCount);
+
+        $statements = [];
+
+        $statements[] =
+            "ALTER TABLE $this->tableName REORGANIZE PARTITION pMAXVALUE INTO
+                (PARTITION p{$futureBoundaryDate->format(Constants::PARTITION_NAME_DATE_FORMAT)} VALUES LESS THAN 
+                (to_days('{$futureBoundaryDate->add('days', 1)->format(Constants::MYSQL_DATE_FORMAT)}')), 
+                PARTITION pMAXVALUE VALUES LESS THAN MAXVALUE);";
+        /* TODO: Add checks and recoveries for when all expected partitions do not already exists.
+         *     The above logic is not complete, failing to handle changing conditions.
+         *     For example, if the `historicalPartitionCount` increased from 7 to 14, many historical
+         *     partitions will not already exist, so we get one very large last partition. Many other
+         *     scenarios exist, all resulting in mega-size partitions until it is eventually deleted.
+         */
+
+        // determine the name of the partition ready for dropping, the partition name format is `p<Ymd>`
+        $partitionForDeletion = "p{$pastBoundaryDate->format(Constants::PARTITION_NAME_DATE_FORMAT)}";
+        // get the list of all partitions for dropping, the one above and older ones if exist
+        $partitionsForDeletion = $this->getPartitionsForDeletion($partitionForDeletion);
+
+        if ($partitionsForDeletion) {
+            $statements[] = "ALTER TABLE $this->tableName DROP PARTITION $partitionsForDeletion;";
+        }
+
+        foreach ($statements as $statement) {
+            $this->comment('EXECUTING STATEMENT:');
+            $this->info($statement);
+            DB::statement($statement);
+        }
+
+        $this->comment('RESULTED TABLE STRUCTURE:');
+        $this->info(DB::select(DB::raw("SHOW CREATE TABLE $this->tableName;"))[0]->{'Create Table'});
+
+        return self::SUCCESS;
+    }
+
+    /**
+     *  Checks all arguments and ensures that they are valid in order to partition the table
+     *
+     * @return void
+     * @throws InvalidArgumentException if any argument passed to this command is invalid.
+     *                                  This includes tables that are not in the expected
+     *                                  state or that do not exist.
+     */
+    private function validateArguments(): void
+    {
+        $error = '';
+
+        if (!$this->hasValidPeriods()) {
+            $this->error(
+                $error .= "The `historicPartitionCount` ($this->historicPartitionCount) and the`futurePartitionCount` "
+                    . "($this->futurePartitionCount) both must be greater than " . self::MINIMUM_NUMBER_OF_PARTITIONS
+                    . "\n"
+            );
+        }
+
+        if (!Schema::hasTable($this->tableName)) {
+            $this->error($error .= "Invalid table name entry. `$this->tableName` was not found.\n");
+        }
+
+        if (!$this->tableIsCorrectlyPartitioned()) {
+            $this->error(
+                $error .= "`$this->tableName` is not compatibly partitioned.  Did you use `table:partition-by-date`?\n"
+            );
+        }
+
+        if ($error) {
+            throw new InvalidArgumentException($error);
+        }
+    }
+
+    /**
+     * Check the validity of the periods.
+     * Expected - integers greater than one.
+     *
+     * @return bool true if provided periods are meet the {@see self::MINIMUM_NUMBER_OF_PARTITIONS}, otherwise false
+     *
+     * TODO: Justify this logic - @danac
+     */
+    private function hasValidPeriods(): bool
+    {
+        foreach ([$this->futurePartitionCount, $this->historicPartitionCount] as $period) {
+            if (
+                filter_var($period, FILTER_VALIDATE_INT) === false
+                || (int)$period < self::MINIMUM_NUMBER_OF_PARTITIONS
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the table is compatibly partitioned by querying its status
+     *
+     * @return bool true if the table is partitioned having a pMAXVALUE partition, otherwise false
+     */
+    private function tableIsCorrectlyPartitioned(): bool
+    {
+        $tableSchema = config('database.connections.mysql.database');
+        $pMaxValuePartition = DB::select(
+            DB::raw(
+                "SELECT PARTITION_NAME as fallThroughPartition FROM INFORMATION_SCHEMA.PARTITIONS
+                    WHERE TABLE_SCHEMA = '$tableSchema' AND TABLE_NAME = '$this->tableName'
+                    AND PARTITION_NAME = 'pMAXVALUE';"
+            )
+        );
+
+        return DbHelper::discoversTableIsAlreadyPartitioned($this->tableName) && $pMaxValuePartition;
+    }
+
+    /**
+     * Get the list of partitions to be dropped by querying their names from the INFORMATION_SCHEMA table
+     * and comparing them to the partition picked as suitable for deletion. The resulting partitions should be older
+     * or equal to the matching one.
+     *
+     * @param string $partitionForDeletion the name of the last (newest) partition that meets the criteria for deletion
+     *                                      - `historicPartitionCount` days past from the day of the command execution
+     *
+     * @return string                       comma separated list of partition names
+     */
+    private function getPartitionsForDeletion(string $partitionForDeletion): string
+    {
+        $tableSchema = config('database.connections.mysql.database');
+        $partitionsForDeletionResult = DB::select(
+            DB::raw(
+                "SELECT GROUP_CONCAT(PARTITION_NAME) as partitions FROM INFORMATION_SCHEMA.PARTITIONS
+                    WHERE TABLE_SCHEMA = '$tableSchema' AND TABLE_NAME = '$this->tableName'
+                    AND 
+                    (
+                        PARTITION_NAME <= '$partitionForDeletion'
+                        OR
+                        (
+                            PARTITION_NAME != 'pMAXVALUE' 
+                            AND PARTITION_NAME NOT REGEXP '^p[0-9]{8}$'
+                        )
+                    );
+                "
+            )
+        );
+
+        return $partitionsForDeletionResult[0]?->partitions ?? '';
+    }
+}

--- a/src/Contracts/Constants.php
+++ b/src/Contracts/Constants.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GuaranteedSoftware\Laravel\DatasourceTools\Contracts;
+
+interface Constants
+{
+    /**
+     * MySql date format, the native representation of the MySql date type
+     * that is used for created_date column comparison when creating / deleting partitions.
+     *
+     * @var string
+     */
+    public const MYSQL_DATE_FORMAT = 'Y-m-d';
+
+    /**
+     * Having hyphens (-) in partition names is against the SQL standard, perhaps it can be used if quoted correctly,
+     * but not recommended. So this format is used. The partition name can not start with a digit so the chosen
+     * format is `p<Ymd>`. The date is included in the partition name, so we can later delete old partitions.
+     * @var string
+     */
+    public const PARTITION_NAME_DATE_FORMAT = 'Ymd';
+}

--- a/src/Helpers/DbHelper.php
+++ b/src/Helpers/DbHelper.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GuaranteedSoftware\Laravel\DatasourceTools\Helpers;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * DB Utility functions to be used across these data source tools
+ */
+class DbHelper
+{
+    /**
+     * Identifies if the given table has already been partitioned
+     *
+     * @param string $tableName whose 'Create_options' are checked for partitions
+     *
+     * @return bool true if the table has been partitioned, otherwise false
+     */
+    public static function discoversTableIsAlreadyPartitioned(string $tableName): bool {
+        $tableStatus = DB::select(DB::raw("SHOW TABLE STATUS LIKE '{$tableName}';"));
+
+        return str_contains((string)$tableStatus[0]?->Create_options, 'partitioned');
+    }
+}

--- a/src/Providers/DatasourceToolsServiceProvider.php
+++ b/src/Providers/DatasourceToolsServiceProvider.php
@@ -52,9 +52,10 @@ class DatasourceToolsServiceProvider extends ServiceProvider
             /**
              * Splits a table into partitions by dates across a range of dates
              *
-             * @param string $partitionColumnName The name of the column to partition against
+             * @param string $tableName The table to be partitioned
              * @param Carbon $startDate The starting partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}, typically, in the past.
              * @param Carbon $endDate The concluding partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}, typically, in the future.
+             * @param string $partitionColumnName The name of the indexed column to partition against
              */
             function (string $tableName, Carbon $startDate, Carbon $endDate, string $partitionColumnName = 'created_at_indexed') {
                 /**

--- a/src/Providers/DatasourceToolsServiceProvider.php
+++ b/src/Providers/DatasourceToolsServiceProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace GuaranteedSoftware\Laravel\DatasourceTools\Providers;
+
+use Carbon\Carbon;
+use GuaranteedSoftware\Laravel\DatasourceTools\Console\Commands\PartitionTableByDateRange;
+use GuaranteedSoftware\Laravel\DatasourceTools\Console\Commands\UpdateTablePartitions;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Bootstrap class auto-discovered by Laravel.  It registers the datasource commands.
+ */
+class DatasourceToolsServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Bootstrap any application services.  This differs from the register
+     * method by executing after all other service provider register methods
+     * have executed, including the complete Laravel Framework.
+     *
+     * Any universal bootstrapping needed that require the entire system to be
+     * available should be accomplished here
+     *
+     * Here, we use this to register our custom commands.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        ///////////////////////////////////////////////
+        // Bootstrap Artisan Commands
+        ///////////////////////////////////////////////
+        if ($this->app->runningInConsole()) {
+            $this->commands(
+                [
+                    PartitionTableByDateRange::class,
+                    UpdateTablePartitions::class
+                ]
+            );
+        }
+
+        ///////////////////////////////////////////////
+        // Bootstrap Blueprint migration extension
+        ///////////////////////////////////////////////
+        DB::macro(
+            'partitionByDateRange',
+            /**
+             * Splits a table into partitions by dates across a range of dates
+             *
+             * @param string $partitionColumnName The name of the column to partition against
+             * @param Carbon $startDate The starting partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}, typically, in the past.
+             * @param Carbon $endDate The concluding partition date in the format of {@see Constants::MYSQL_DATE_FORMAT}, typically, in the future.
+             */
+            function (string $tableName, Carbon $startDate, Carbon $endDate, string $partitionColumnName = 'created_at_indexed') {
+                /**
+                 * @var DatabaseManager $this is the DatabaseManager rebound by \Illuminate\Support\Traits\Macroable::__call
+                 */
+
+                $dbManagerStatements = [];
+
+                Schema::table(
+                    $tableName,
+                    function (Blueprint $table) use (&$dbManagerStatements, $tableName, $startDate, $endDate, $partitionColumnName) {
+                        Artisan::call(
+                            PartitionTableByDateRange::class,
+                            [
+                                'tableName' => $tableName,
+                                'startDate' => $startDate,
+                                'endDate' => $endDate,
+                                '--partitionColumnName' => $partitionColumnName,
+                                '--blueprint' => $table,
+                                '--databaseManagerStatements' => $dbManagerStatements,
+                            ]
+                        );
+                    }
+                );
+
+                foreach ($dbManagerStatements as $statement) {
+                    DB::statement($statement);
+                }
+            }
+        );
+    }
+}

--- a/stubs/database/migrations/add_partition_column.php
+++ b/stubs/database/migrations/add_partition_column.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add the column to the table that will be used for partitioning.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /* @see \GuaranteedSoftware\Laravel\\DatasourceTools\Console\Commands\PartitionTableByDateRange::addPartitionColumnToBlueprint() */
+        Schema::table('{{tableName}}', function (Blueprint $table) {
+            $table->date('{{partitionColumnName}}')->default(DB::raw('(CURRENT_DATE)'))->index();
+            $table->unique(['id']);
+            $table->dropPrimary(['id']);
+            $table->primary(['id', '{{partitionColumnName}}']);
+        });
+
+        if (Schema::hasColumn('{{tableName}}', 'created_at')) {
+            DB::statement("UPDATE {{tableName}} SET {{partitionColumnName}} = date(created_at);");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('{{tableName}}', function (Blueprint $table) {
+            $table->dropPrimary(['id', '{{partitionColumnName}}']);
+            $table->primary(['id']);
+            $table->dropUnique(['id']);
+
+            $table->dropIndex(['{{partitionColumnName}}']);
+            $table->dropColumn(['{{partitionColumnName}}']);
+        });
+    }
+};

--- a/stubs/database/migrations/create_partitions.php
+++ b/stubs/database/migrations/create_partitions.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Migration to initially partition a table with partitions tagged by date.
+ * The data already stored in the database is split into "historic" partitions.
+ * All data older than the first tag date is put in the first, and "oldest" historic partition.
+ * All other data will be placed in their matching historic partitions.
+ * Additionally, inactive partitions may be created for future dates if the
+ * {@see \Console\Commands\PartitionTableByDate::$endDate} is
+ * in the future.  These partitions become active historic partitions when their tag date arrives.
+ * Finally, a fallback `pMAXVALUE` partition is created. In the event that the current date exceeds
+ * any created partition, the data will be stored in the otherwise perennially inactive `pMAXVALUE` partition.
+ *
+ * @see App\Console\Commands\PartitionTable
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement
+        (
+            "
+                {{statement}}
+            "
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::select(DB::raw("ALTER TABLE {{tableName}} REMOVE PARTITIONING;"));
+    }
+};


### PR DESCRIPTION
**Context:**
This Laravel extension allows users to partition MySQL tables by date via either console commands or in the the context of a migration as a DB macro.

It is our public repository and [our first composer package](https://packagist.org/packages/guaranteed.software/laravel-datasource-tools).

Asana Link: https://app.asana.com/0/1202505914853591/1205497603354271